### PR TITLE
fix: 缩放后辅助线未对齐

### DIFF
--- a/src/core/initAligningGuidelines.js
+++ b/src/core/initAligningGuidelines.js
@@ -40,8 +40,8 @@ function initAligningGuidelines(canvas) {
     ctx.lineWidth = aligningLineWidth;
     ctx.strokeStyle = aligningLineColor;
     ctx.beginPath();
-    ctx.moveTo((x1 + viewportTransform[4]) * zoom, (y1 + viewportTransform[5]) * zoom);
-    ctx.lineTo((x2 + viewportTransform[4]) * zoom, (y2 + viewportTransform[5]) * zoom);
+    ctx.moveTo(x1 * zoom + viewportTransform[4], y1 * zoom + viewportTransform[5]);
+    ctx.lineTo(x2 * zoom + viewportTransform[4], y2 * zoom + viewportTransform[5]);
     ctx.stroke();
     ctx.restore();
   }


### PR DESCRIPTION
fix https://github.com/nihaojob/vue-fabric-editor/issues/66
![网页捕获_3-4-2023_14383_127 0 0 1](https://user-images.githubusercontent.com/8676207/229430579-26b1365a-325d-41de-80d0-53454a2f3dbe.jpeg)
