### PR TITLE
feat(拖拽): 添加空格切换拖拽状态

### DIFF
--- a/src/components/dragMode.vue
+++ b/src/components/dragMode.vue
@@ -43,6 +43,22 @@ export default {
         this.canvas.editor.editorWorkspace.endDring();
       }
     },
+    handleKeyDown() {
+      this.status = true;
+      this.canvas.editor.editorWorkspace.startDring();
+    },
+    handleKeyUp() {
+      this.status = false;
+      this.canvas.editor.editorWorkspace.endDring();
+    },
+  },
+  mounted() {
+    window.addEventListener('keydown', this.handleKeyDown);
+    window.addEventListener('keyup', this.handleKeyUp);
+  },
+  beforeUnmount() {
+    window.removeEventListener('keydown', this.handleKeyDown);
+    window.removeEventListener('keyup', this.handleKeyUp);
   },
 };
 </script>


### PR DESCRIPTION
按照大多数的编辑器软件，普遍用户都习惯于按住空格来进行拖拽视图，所以我添加了一段小小的代码，支持按住空格进行拖拽😊