### PR TITLE
fix: :bug: 移除导致 `unplugin-auto-import` 自动引入不正常解析的注释

### DIFF
--- a/src/components/align.vue
+++ b/src/components/align.vue
@@ -170,7 +170,6 @@
 </template>
 
 <script setup name="Align">
-// import { fabric } from 'fabric';
 import useSelect from '@/hooks/select';
 
 const { mixinState, canvasEditor } = useSelect();


### PR DESCRIPTION
详细描述见 #267 