### PR TITLE
fix(Editor): 增加Editor销毁函数

### DIFF
--- a/src/views/home/index.vue
+++ b/src/views/home/index.vue
@@ -248,6 +248,7 @@ onMounted(() => {
   }
 });
 
+onUnmounted(() => canvasEditor.destory());
 const rulerSwitch = (val) => {
   if (val) {
     canvasEditor.rulerEnable();


### PR DESCRIPTION
Editor 需要一个销毁函数，组件卸载的时候用来销毁Editor。之后单元测试，也能方便销毁测试Editor实例。


<img width="533" alt="image" src="https://github.com/nihaojob/vue-fabric-editor/assets/17617116/a9d63090-f6e1-4109-8382-c993f9f709df">

因为代理API是直接通过[]方式来代理，销毁函数暂时没法销毁通过代理API的数据