### PR TITLE
fix: 修复ColorPicker设置颜色失效

### DIFF
--- a/src/components/bgBar.vue
+++ b/src/components/bgBar.vue
@@ -3,7 +3,7 @@
     <Divider orientation="left" plain>{{ $t('color') }}</Divider>
     <Form :label-width="40">
       <FormItem :label="$t('color')" prop="name">
-        <ColorPicker v-model="color" @on-change="setThisColor" alpha size="small" transfer />
+        <ColorPicker v-model="color" @on-change="setThisColor" alpha size="small" />
       </FormItem>
     </Form>
     <Divider orientation="left" plain>{{ $t('color_macthing') }}</Divider>
@@ -58,7 +58,7 @@ const colorList = computed(() => [
   },
 ]);
 
-const color = ref('');
+const color = ref('rgba(255, 255, 255, 1)');
 // 背景颜色设置
 const setThisColor = () => {
   setColor(color.value);
@@ -75,6 +75,9 @@ function setColor(color) {
 <style scoped lang="less">
 :deep(.ivu-form-item) {
   margin-bottom: 0;
+  .ivu-color-picker {
+    display: unset;
+  }
 }
 .img {
   width: 50px;

--- a/src/components/waterMark.vue
+++ b/src/components/waterMark.vue
@@ -42,7 +42,7 @@
     <div class="setting-item">
       <span class="mr-10px">{{ $t('waterMark.setting.color') }}</span>
 
-      <ColorPicker v-model="waterMarkState.color" alpha size="small" transfer />
+      <ColorPicker v-model="waterMarkState.color" alpha size="small" />
     </div>
     <div class="setting-item">
       <span class="mr-10px">{{ $t('waterMark.setting.position.label') }}</span>


### PR DESCRIPTION
修复[issue#362](https://github.com/nihaojob/vue-fabric-editor/issues/362)
经过排查发现是view ui plus的bug：当ColorPicker使用transfer属性时就会出现手动设置颜色失效
本次提交的改动：
1.删除transfer属性
2.右侧的ColorPicker不使用transfer会有样式问题，需要调整样式



