### PR TITLE
refactor: 重构选择事件监听hook

### DIFF
--- a/src/hooks/select.ts
+++ b/src/hooks/select.ts
@@ -3,11 +3,10 @@
  * @version:
  * @Author: June
  * @Date: 2023-04-23 21:10:05
- * @LastEditors: 秦少卫
- * @LastEditTime: 2024-04-10 14:42:34
+ * @LastEditors: wuchenguang1998
+ * @LastEditTime: 2024-05-04 15:37:06
  */
-import Editor, { EventType } from '@kuaitu/core';
-const { SelectEvent, SelectMode } = EventType;
+import Editor from '@kuaitu/core';
 interface Selector {
   mSelectMode: SelectMode;
   mSelectOneType: string | undefined;
@@ -17,54 +16,13 @@ interface Selector {
 }
 
 export default function useSelect() {
-  const state = reactive<Selector>({
-    mSelectMode: SelectMode.EMPTY,
-    mSelectOneType: '',
-    mSelectId: '', // 选择id
-    mSelectIds: [], // 选择id
-    mSelectActive: [],
-  });
-
   const fabric = inject('fabric');
   const canvasEditor = inject('canvasEditor') as Editor;
-
-  const selectOne = (e: [fabric.Object]) => {
-    state.mSelectMode = SelectMode.ONE;
-    if (e[0]) {
-      state.mSelectId = e[0].id;
-      state.mSelectOneType = e[0].type;
-      state.mSelectIds = e.map((item) => item.id);
-    }
-  };
-
-  const selectMulti = (e: fabric.Object[]) => {
-    state.mSelectMode = SelectMode.MULTI;
-    state.mSelectId = '';
-    state.mSelectIds = e.map((item) => item.id);
-  };
-
-  const selectCancel = () => {
-    state.mSelectId = '';
-    state.mSelectIds = [];
-    state.mSelectMode = SelectMode.EMPTY;
-    state.mSelectOneType = '';
-  };
-
-  onMounted(() => {
-    canvasEditor.on(SelectEvent.ONE, selectOne);
-    canvasEditor.on(SelectEvent.MULTI, selectMulti);
-    canvasEditor.on(SelectEvent.CANCEL, selectCancel);
-  });
-
-  onBeforeMount(() => {
-    canvasEditor.off(SelectEvent.ONE, selectOne);
-    canvasEditor.off(SelectEvent.MULTI, selectMulti);
-    canvasEditor.off(SelectEvent.CANCEL, selectCancel);
-  });
+  const mixinState = inject('mixinState') as Selector;
 
   return {
     fabric,
     canvasEditor,
-    mixinState: state,
+    mixinState,
   };
 }

--- a/src/hooks/useSelectListen.ts
+++ b/src/hooks/useSelectListen.ts
@@ -1,0 +1,65 @@
+/*
+ * @Descripttion: useSelectListen
+ * @version:
+ * @Author: wuchenguang1998
+ * @Date: 2024-05-04 14:36:49
+ * @LastEditors: wuchenguang1998
+ * @LastEditTime: 2024-05-04 15:27:11
+ */
+import Editor, { EventType } from '@kuaitu/core';
+const { SelectEvent, SelectMode } = EventType;
+interface Selector {
+  mSelectMode: SelectMode;
+  mSelectOneType: string | undefined;
+  mSelectId: string | undefined;
+  mSelectIds: (string | undefined)[];
+  mSelectActive: unknown[];
+}
+
+export default function useSelectListen(canvasEditor: Editor) {
+  const state = reactive<Selector>({
+    mSelectMode: SelectMode.EMPTY,
+    mSelectOneType: '',
+    mSelectId: '', // 选择id
+    mSelectIds: [], // 选择id
+    mSelectActive: [],
+  });
+
+  const selectOne = (e: [fabric.Object]) => {
+    state.mSelectMode = SelectMode.ONE;
+    if (e[0]) {
+      state.mSelectId = e[0].id;
+      state.mSelectOneType = e[0].type;
+      state.mSelectIds = e.map((item) => item.id);
+    }
+  };
+
+  const selectMulti = (e: fabric.Object[]) => {
+    state.mSelectMode = SelectMode.MULTI;
+    state.mSelectId = '';
+    state.mSelectIds = e.map((item) => item.id);
+  };
+
+  const selectCancel = () => {
+    state.mSelectId = '';
+    state.mSelectIds = [];
+    state.mSelectMode = SelectMode.EMPTY;
+    state.mSelectOneType = '';
+  };
+
+  onMounted(() => {
+    canvasEditor.on(SelectEvent.ONE, selectOne);
+    canvasEditor.on(SelectEvent.MULTI, selectMulti);
+    canvasEditor.on(SelectEvent.CANCEL, selectCancel);
+  });
+
+  onBeforeMount(() => {
+    canvasEditor.off(SelectEvent.ONE, selectOne);
+    canvasEditor.off(SelectEvent.MULTI, selectMulti);
+    canvasEditor.off(SelectEvent.CANCEL, selectCancel);
+  });
+
+  return {
+    mixinState: state,
+  };
+}

--- a/src/views/home/index.vue
+++ b/src/views/home/index.vue
@@ -178,6 +178,9 @@ import attribute from '@/components/attribute.vue';
 // 功能组件
 import { fabric } from 'fabric';
 
+// hooks
+import useSelectListen from '@/hooks/useSelectListen';
+
 const APIHOST = import.meta.env.APP_APIHOST;
 
 import Editor, {
@@ -281,8 +284,11 @@ const switchAttrBar = () => {
   state.attrBarShow = !state.attrBarShow;
 };
 
+const { mixinState } = useSelectListen(canvasEditor);
+
 provide('fabric', fabric);
 provide('canvasEditor', canvasEditor);
+provide('mixinState', mixinState);
 </script>
 <style lang="less" scoped>
 .logo {


### PR DESCRIPTION
修复[issue#364](https://github.com/nihaojob/vue-fabric-editor/issues/364)
出现问题的原因是：
emitter监听了太多事件，超过了默认最大监听数。排查发现，多个组件都调用了src\hooks\select.ts的自定义hook，这个hook在onMounted时监听了3个画布元素的选择事件。导致多个组件调用这hook时，这3个事件被反复监听。通过console.log(canvasEditor.listenerCount(SelectEvent.ONE));查看，发现selectOne监听了近30次，其中多数是来源于这个自定义hook。
本次提交的改动：
将src\hooks\select.ts主要监听逻辑抽取成新的hook（useSelectListen），在src\views\home\index.vue调用一次，并将mixinState暴露。原来的src\hooks\select.ts通过inject获取mixinState，提供给有需要的组件。
最终效果：
选择事件的监听大幅减少，控制台警告消除。
