### PR TITLE
fix: 修复元素与图层无法对应的问题

### DIFF
--- a/packages/core/ServersPlugin.ts
+++ b/packages/core/ServersPlugin.ts
@@ -96,6 +96,12 @@ class ServersPlugin {
   }
 
   loadJSON(jsonFile: string, callback?: () => void) {
+    // 确保元素存在id
+    const temp = JSON.parse(jsonFile);
+    temp.objects.forEach((item: any) => {
+      !item.id && (item.id = uuid());
+    });
+    jsonFile = JSON.stringify(temp);
     // 加载前钩子
     this.editor.hooksEntity.hookImportBefore.callAsync(jsonFile, () => {
       this.canvas.loadFromJSON(jsonFile, () => {


### PR DESCRIPTION
修复[issue#369](https://github.com/nihaojob/vue-fabric-editor/issues/369)
原因是模板的图片少了id。
在导入模板或文件时，先预处理，如果元素没有id，则加上唯一id。




