### PR TITLE
feat: 新增细尾箭头绘制元素(thinTailArrow)

### DIFF
--- a/packages/core/objects/ThinTailArrow.js
+++ b/packages/core/objects/ThinTailArrow.js
@@ -34,11 +34,11 @@ fabric.ThinTailArrow = fabric.util.createClass(fabric.Line, {
     // 绘制箭头
     ctx.beginPath();
     ctx.moveTo(0, 0);
-    ctx.lineTo(length - 20, -5);
+    ctx.lineTo(length - 18, -5);
     ctx.lineTo(length - 20, -12);
     ctx.lineTo(length, 0);
     ctx.lineTo(length - 20, 12);
-    ctx.lineTo(length - 20, 5);
+    ctx.lineTo(length - 18, 5);
     ctx.lineTo(0, 0);
     ctx.lineWidth = this.strokeWidth;
     ctx.strokeStyle = this.stroke;

--- a/packages/core/objects/ThinTailArrow.js
+++ b/packages/core/objects/ThinTailArrow.js
@@ -1,0 +1,57 @@
+/*
+ * @Author: wuchenguang1998
+ * @Date: 2024-05-10 10:46:10
+ * @LastEditors: wuchenguang1998
+ * @LastEditTime: 2024-05-10 22:08:51
+ * @Description: 细尾箭头，支持控制条拖拽不变形
+ */
+import { fabric } from 'fabric';
+
+fabric.ThinTailArrow = fabric.util.createClass(fabric.Line, {
+  type: 'thinTailArrow',
+  superType: 'drawing',
+  initialize(points, options) {
+    if (!points) {
+      const { x1, x2, y1, y2 } = options;
+      points = [x1, y1, x2, y2];
+    }
+    options = options || {};
+    this.callSuper('initialize', points, options);
+  },
+  _render(ctx) {
+    ctx.save();
+    // 乘或除对应的scaleX(Y)，抵消元素放缩造成的影响，使箭头不会变形
+    ctx.scale(1 / this.scaleX, 1 / this.scaleY);
+    const xDiff = (this.x2 - this.x1) * this.scaleX;
+    const yDiff = (this.y2 - this.y1) * this.scaleY;
+    ctx.translate(-xDiff / 2, -yDiff / 2);
+    // 箭头方位角
+    const angle = Math.atan2(yDiff, xDiff);
+    ctx.rotate(angle);
+    // 箭头总长(最小长度是20)
+    let length = Math.hypot(xDiff, yDiff);
+    length = length < 20 ? 20 : length;
+    // 绘制箭头
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.lineTo(length - 20, -5);
+    ctx.lineTo(length - 20, -12);
+    ctx.lineTo(length, 0);
+    ctx.lineTo(length - 20, 12);
+    ctx.lineTo(length - 20, 5);
+    ctx.lineTo(0, 0);
+    ctx.lineWidth = this.strokeWidth;
+    ctx.strokeStyle = this.stroke;
+    ctx.fillStyle = this.fill;
+    ctx.stroke();
+    ctx.fill();
+    ctx.restore();
+  },
+});
+
+fabric.ThinTailArrow.fromObject = (options, callback) => {
+  const { x1, x2, y1, y2 } = options;
+  return callback(new fabric.ThinTailArrow([x1, y1, x2, y2], options));
+};
+
+export default fabric.ThinTailArrow;

--- a/packages/core/plugin/DrawLinePlugin.ts
+++ b/packages/core/plugin/DrawLinePlugin.ts
@@ -9,6 +9,7 @@
 import { v4 as uuid } from 'uuid';
 import { fabric } from 'fabric';
 import Arrow from '../objects/Arrow';
+import ThinTailArrow from '../objects/ThinTailArrow';
 import Editor from '../Editor';
 type IEditor = Editor;
 
@@ -16,9 +17,9 @@ class DrawLinePlugin {
   public canvas: fabric.Canvas;
   public editor: IEditor;
   static pluginName = 'DrawLinePlugin';
-  static apis = ['setArrow', 'setMode'];
+  static apis = ['setLineType', 'setMode'];
   isDrawingLineMode: boolean;
-  isArrow: boolean;
+  lineType: string;
   lineToDraw: any;
   pointer: any;
   pointerPoints: any;
@@ -29,7 +30,7 @@ class DrawLinePlugin {
 
     this.isDrawingLine = false;
     this.isDrawingLineMode = false;
-    this.isArrow = false;
+    this.lineType = '';
     this.lineToDraw = null;
     this.pointer = null;
     this.pointerPoints = null;
@@ -49,13 +50,34 @@ class DrawLinePlugin {
       this.isDrawingLine = true;
       this.pointer = canvas.getPointer(o.e);
       this.pointerPoints = [this.pointer.x, this.pointer.y, this.pointer.x, this.pointer.y];
-
-      const NodeHandler = this.isArrow ? Arrow : fabric.Line;
-      this.lineToDraw = new NodeHandler(this.pointerPoints, {
+      let NodeHandler;
+      let opts: any = {
         strokeWidth: 2,
         stroke: '#000000',
         id: uuid(),
-      });
+      };
+      switch (this.lineType) {
+        case 'line':
+          NodeHandler = fabric.Line;
+          break;
+        case 'arrow':
+          NodeHandler = Arrow;
+          break;
+        case 'thinTailArrow':
+          NodeHandler = ThinTailArrow;
+          opts = {
+            strokeWidth: 2,
+            stroke: '#ff0000',
+            fill: '#ff0000',
+            id: uuid(),
+          };
+          break;
+        default:
+          break;
+      }
+      if (!NodeHandler) throw new Error('Draw failed: invalid lineType.');
+
+      this.lineToDraw = new NodeHandler(this.pointerPoints, opts);
 
       this.lineToDraw.selectable = false;
       this.lineToDraw.evented = false;
@@ -64,7 +86,8 @@ class DrawLinePlugin {
     });
 
     canvas.on('mouse:move', (o) => {
-      if (!this.isDrawingLine) return;
+      if (!this.isDrawingLine || !['line', 'arrow', 'thinTailArrow'].includes(this.lineType))
+        return;
       canvas.discardActiveObject();
       const activeObject = canvas.getActiveObject();
       if (activeObject) return;
@@ -105,8 +128,8 @@ class DrawLinePlugin {
     });
   }
 
-  setArrow(params: any) {
-    this.isArrow = params;
+  setLineType(params: any) {
+    this.lineType = params;
   }
 
   setMode(params: any) {

--- a/src/components/attribute.vue
+++ b/src/components/attribute.vue
@@ -320,6 +320,7 @@ const baseType = [
   'group',
   'line',
   'arrow',
+  'thinTailArrow',
 ];
 // 文字元素
 const textType = ['i-text', 'textbox', 'text'];

--- a/src/components/tools.vue
+++ b/src/components/tools.vue
@@ -109,8 +109,8 @@
     <Divider plain orientation="left">{{ $t('draw_elements') }}</Divider>
     <div class="tool-box">
       <span
-        @click="drawingLineModeSwitch(false)"
-        :class="state.isDrawingLineMode && !state.isArrow && 'bg'"
+        @click="drawingLineModeSwitch('line')"
+        :class="state.isDrawingLineMode && state.lineType === 'line' && 'bg'"
       >
         <svg
           t="1673022047861"
@@ -135,8 +135,8 @@
         </svg>
       </span>
       <span
-        @click="drawingLineModeSwitch(true)"
-        :class="state.isDrawingLineMode && state.isArrow && 'bg'"
+        @click="drawingLineModeSwitch('arrow')"
+        :class="state.isDrawingLineMode && state.lineType === 'arrow' && 'bg'"
       >
         <!-- <svg t="1673022047861" class="icon" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="4206" width="20" height="20"><path d="M187.733333 1024h-170.666666c-10.24 0-17.066667-6.826667-17.066667-17.066667v-170.666666c0-10.24 6.826667-17.066667 17.066667-17.066667h170.666666c10.24 0 17.066667 6.826667 17.066667 17.066667v170.666666c0 10.24-6.826667 17.066667-17.066667 17.066667zM34.133333 989.866667h136.533334v-136.533334H34.133333v136.533334zM1006.933333 204.8h-170.666666c-10.24 0-17.066667-6.826667-17.066667-17.066667v-170.666666c0-10.24 6.826667-17.066667 17.066667-17.066667h170.666666c10.24 0 17.066667 6.826667 17.066667 17.066667v170.666666c0 10.24-6.826667 17.066667-17.066667 17.066667zM853.333333 170.666667h136.533334V34.133333h-136.533334v136.533334z" fill="" p-id="4207"></path><path d="M187.733333 853.333333c-3.413333 0-10.24 0-13.653333-3.413333-6.826667-6.826667-6.826667-17.066667 0-23.893333l648.533333-648.533334c6.826667-6.826667 17.066667-6.826667 23.893334 0s6.826667 17.066667 0 23.893334l-648.533334 648.533333c0 3.413333-6.826667 3.413333-10.24 3.413333z" fill="" p-id="4208"></path></svg> -->
         <svg
@@ -153,6 +153,27 @@
             d="M320 738.133333L827.733333 230.4l-29.866666-29.866667L290.133333 708.266667v-268.8h-42.666666v341.333333h341.333333v-42.666667H320z"
             fill="#444444"
             p-id="2660"
+          ></path>
+        </svg>
+      </span>
+      <span
+        @click="drawingLineModeSwitch('thinTailArrow')"
+        :class="state.isDrawingLineMode && state.lineType === 'thinTailArrow' && 'bg'"
+      >
+        <svg
+          t="1715323097309"
+          class="icon"
+          viewBox="0 0 1024 1024"
+          version="1.1"
+          xmlns="http://www.w3.org/2000/svg"
+          p-id="24572"
+          width="20"
+          height="20"
+        >
+          <path
+            d="M485.954269 735.978673 643.38051 811.107852C688.831327 832.798434 686.17686 860.459274 635.3838 871.903075L81.378406 996.721881C31.19882 1008.027444-1.313538 976.266799 10.130269 925.473745L134.949081 371.468357C146.254656 321.288783 173.611855 317.095036 195.744311 363.471653L270.873453 520.897858 903.670271 62.052983C986.301645 2.136458 1004.805285 20.426857 944.799125 103.181838L485.954269 735.978673Z"
+            fill="#444444"
+            p-id="24573"
           ></path>
         </svg>
       </span>
@@ -178,7 +199,7 @@ const { t } = useI18n();
 const { fabric, canvasEditor } = useSelect();
 const state = reactive({
   isDrawingLineMode: false,
-  isArrow: false,
+  lineType: false,
 });
 // let drawHandler = null;
 
@@ -297,11 +318,11 @@ const addRect = (option) => {
   }
   canvasEditor.canvas.setActiveObject(rect);
 };
-const drawingLineModeSwitch = (isArrow) => {
-  state.isArrow = isArrow;
+const drawingLineModeSwitch = (type) => {
+  state.lineType = type;
   state.isDrawingLineMode = !state.isDrawingLineMode;
   canvasEditor.setMode(state.isDrawingLineMode);
-  canvasEditor.setArrow(isArrow);
+  canvasEditor.setLineType(type);
 
   // this.canvasEditor.setMode(this.isDrawingLineMode);
   // this.canvasEditor.setArrow(isArrow);


### PR DESCRIPTION
实现[issue#381](https://github.com/nihaojob/vue-fabric-editor/issues/381)
可以正常绘制，并且支持拖拽控制条时保持箭头不变形，具体效果：
![微信截图_20240511101742](https://github.com/nihaojob/vue-fabric-editor/assets/63847336/227eaad5-fea3-4f0d-ad31-1511e7da749c)



