### PR TITLE
fix: 修复元素拖拽上图没有判断画布区域的问题

### DIFF
--- a/src/components/fontStyle.vue
+++ b/src/components/fontStyle.vue
@@ -59,6 +59,7 @@
 
 <script setup name="ImportSvg">
 import useSelect from '@/hooks/select';
+import useCalculate from '@/hooks/useCalculate';
 import usePageList from '@/hooks/pageList';
 import { fabric } from 'fabric';
 import { v4 as uuid } from 'uuid';
@@ -90,8 +91,11 @@ const {
 
 const { canvasEditor } = useSelect();
 
+const { isOutsideCanvas } = useCalculate();
+
 // 按照类型渲染
 const dragItem = async (e, item) => {
+  if (isOutsideCanvas(e.clientX, e.clientY)) return;
   Spin.show({
     render: (h) => h('div', t('alert.loading_data')),
   });

--- a/src/components/importSvgEl.vue
+++ b/src/components/importSvgEl.vue
@@ -66,6 +66,7 @@
 
 <script setup name="ImportSvg">
 import useSelect from '@/hooks/select';
+import useCalculate from '@/hooks/useCalculate';
 import usePageList from '@/hooks/pageList';
 import { fabric } from 'fabric';
 import { v4 as uuid } from 'uuid';
@@ -96,8 +97,11 @@ const {
 
 const { canvasEditor } = useSelect();
 
+const { isOutsideCanvas } = useCalculate();
+
 // 按照类型渲染
 const dragItem = (e) => {
+  if (isOutsideCanvas(e.clientX, e.clientY)) return;
   const target = e.target;
   const imgType = canvasEditor.getImageExtension(target.src);
   if (imgType === 'svg') {

--- a/src/hooks/useCalculate.js
+++ b/src/hooks/useCalculate.js
@@ -1,0 +1,26 @@
+/*
+ * @Descripttion: useCalculate
+ * @version:
+ * @Author: wuchenguang1998
+ * @Date: 2024-05-18 15:42:17
+ * @LastEditors: wuchenguang1998
+ * @LastEditTime: 2024-05-18 17:28:34
+ */
+
+export default function useCalculate() {
+  const canvasEditor = inject('canvasEditor');
+
+  // 获取画布的DOMRect对象
+  const getCanvasBound = () => canvasEditor.canvas.getSelectionElement().getBoundingClientRect();
+
+  // 判断拖拽结束的坐标是否在画布外
+  const isOutsideCanvas = (x, y) => {
+    const { left, right, top, bottom } = getCanvasBound();
+    return x < left || x > right || y < top || y > bottom;
+  };
+
+  return {
+    getCanvasBound,
+    isOutsideCanvas,
+  };
+}


### PR DESCRIPTION
修复[issue#390](https://github.com/nihaojob/vue-fabric-editor/issues/390)
本次提交的改动：dragend事件拿到拖拽结束点，如果不在画布内，直接return