### PR TITLE
fix: 修复多边形编辑时控制点消失问题

### DIFF
--- a/packages/core/plugin/PolygonModifyPlugin.ts
+++ b/packages/core/plugin/PolygonModifyPlugin.ts
@@ -90,21 +90,24 @@ function renderIconEdge(
   left: number,
   top: number,
   styleOverride: any,
-  fabricObject: fabric.Object
+  fabricObject: fabric.Object,
+  img: HTMLImageElement
 ) {
-  const img = document.createElement('img');
-  img.src = edgeImg;
   drawImg(ctx, left, top, img, 25, 25, fabric.util.degreesToRadians(fabricObject.angle || 0));
 }
 
 class PolygonModifyPlugin {
   public isEdit: boolean;
+  private img: HTMLImageElement;
   static pluginName = 'PolygonModifyPlugin';
   static events = [];
   static apis = ['toggleEdit', 'activeEdit', 'inActiveEdit'];
 
   constructor(public canvas: fabric.Canvas, public editor: IEditor) {
     this.isEdit = false;
+    const img = document.createElement('img');
+    img.src = edgeImg;
+    this.img = img;
     this.init();
   }
   init() {
@@ -124,6 +127,7 @@ class PolygonModifyPlugin {
       this._ensureEvent(poly);
       if (poly.points == null) return;
       const lastControl = poly.points.length - 1;
+      const This = this;
       poly.controls = poly.points.reduce<Record<string, PointIndexControl>>(function (
         acc,
         point,
@@ -133,7 +137,7 @@ class PolygonModifyPlugin {
           positionHandler: polygonPositionHandler,
           actionHandler: anchorWrapper(index > 0 ? index - 1 : lastControl, actionHandler),
           actionName: 'modifyPolygon',
-          render: renderIconEdge,
+          render: (...args) => renderIconEdge(...args, This.img),
         });
         Object.defineProperty(acc['p' + index], 'pointIndex', { value: index });
         return acc;


### PR DESCRIPTION
修复[issue#396](https://github.com/nihaojob/vue-fabric-editor/issues/396)
本次提交的改动：将img的创建放在插件初始化时执行，同时也避免每次渲染要重复创建控制点img




