### PR TITLE
fix: 解决默认文字颜色无法选中问题

### DIFF
--- a/src/components/tools.vue
+++ b/src/components/tools.vue
@@ -247,6 +247,7 @@ const addText = (option) => {
     ...defaultPosition,
     ...option,
     fontSize: 80,
+    fill: '#000000FF',
     id: uuid(),
   });
   canvasEditor.canvas.add(text);
@@ -274,6 +275,7 @@ const addTextBox = (option) => {
     splitByGrapheme: true,
     width: 400,
     fontSize: 80,
+    fill: '#000000FF',
     id: uuid(),
   });
   canvasEditor.canvas.add(text);


### PR DESCRIPTION
添加默认文字颜色 避免初始化rgb(0, 0, 0)颜色影响colorpikcer组件的正常显示




