### PR TITLE
fix: pathText和freeDraw元素绘制时设置唯一id

### DIFF
--- a/packages/core/plugin/FreeDrawPlugin.ts
+++ b/packages/core/plugin/FreeDrawPlugin.ts
@@ -1,5 +1,6 @@
 import { fabric } from 'fabric';
 import Editor from '../Editor';
+import { v4 as uuid } from 'uuid';
 
 type IEditor = Editor;
 
@@ -12,14 +13,28 @@ export default class FreeDrawPlugin {
   static apis = ['startDraw', 'endDraw'];
   constructor(public canvas: fabric.Canvas, public editor: IEditor) {}
 
+  _bindEvent() {
+    this.canvas.on('path:created', this._createdHandler);
+  }
+
+  _unbindEvent() {
+    this.canvas.off('path:created', this._createdHandler);
+  }
+
+  _createdHandler = (opt: any) => {
+    opt.path.set('id', uuid());
+  };
+
   startDraw(options: DrawOptions) {
     this.canvas.isDrawingMode = true;
     this.canvas.freeDrawingBrush = new fabric.PencilBrush(this.canvas);
     this.canvas.freeDrawingBrush.width = options.width;
+    this._bindEvent();
   }
   endDraw() {
     if (this.canvas.isDrawingMode) {
       this.canvas.isDrawingMode = false;
+      this._unbindEvent();
       return;
     }
   }

--- a/packages/core/plugin/PathTextPlugin.ts
+++ b/packages/core/plugin/PathTextPlugin.ts
@@ -1,5 +1,6 @@
 import { fabric } from 'fabric';
 import Editor from '../Editor';
+import { v4 as uuid } from 'uuid';
 
 type IEditor = Editor;
 type DrawOptions = {
@@ -31,6 +32,7 @@ export default class PathTextPlugin {
       left: path.left,
       fill: this.options.color,
       path: path,
+      id: uuid(),
     });
     this.canvas.add(textObject);
   };


### PR DESCRIPTION
修复[issue#415](https://github.com/nihaojob/vue-fabric-editor/issues/415)
出现问题的原因是没有设置绘制元素的唯一id


