### PR TITLE
fix: 修复路径文本元素导入json失败

### DIFF
--- a/packages/core/plugin/PathTextPlugin.ts
+++ b/packages/core/plugin/PathTextPlugin.ts
@@ -26,13 +26,17 @@ export default class PathTextPlugin {
     path.set({ stroke: this.options.lineColor });
     const text = this.options.defaultText;
     const fontSize = this.options.defaultFontSize;
-    const textObject = new fabric.Text(text, {
+    const textObject = new fabric.IText(text, {
+      shadow: '',
+      fontFamily: 'arial',
       fontSize: fontSize,
       top: path.top,
       left: path.left,
       fill: this.options.color,
       path: path,
       id: uuid(),
+      // 路径文字元素禁止在画布上直接编辑
+      editable: false,
     });
     this.canvas.add(textObject);
   };

--- a/src/components/attributeTextContent.vue
+++ b/src/components/attributeTextContent.vue
@@ -58,7 +58,7 @@ onBeforeUnmount(() => {
 <template>
   <div
     class="box attr-item-box"
-    v-if="mixinState.mSelectMode === 'one' && mixinState.mSelectOneType === 'text'"
+    v-if="mixinState.mSelectMode === 'one' && mixinState.mSelectOneType === 'i-text'"
   >
     <!-- <h3>数据</h3> -->
     <Divider plain orientation="left"><h4>文本内容</h4></Divider>


### PR DESCRIPTION
修复[issue#417](https://github.com/nihaojob/vue-fabric-editor/issues/417)
加载json回显失败，有两层原因：路径回显失败、文字回显失败
- 针对路径回显失败，做了以下改动：
1.将绘制的元素由fabric.Text改为fabric.IText
2.加载json时先忽略path属性，上图后再加上
- 针对文字回显失败，做了以下改动
在绘制时设置fontFamily