### PR TITLE
fix(stroke): 修复描边色彩选择器位置

### DIFF
--- a/src/components/imgStroke.vue
+++ b/src/components/imgStroke.vue
@@ -119,7 +119,6 @@ const onSliderChange = (val: number) => {
 };
 
 const onColorChange = (val: string) => {
-  console.log('onColorChnage', val);
   strokeColor.value = val;
   updateStroke();
 };

--- a/src/components/imgStroke.vue
+++ b/src/components/imgStroke.vue
@@ -52,7 +52,7 @@
         </div>
 
         <div>
-          <ColorPicker v-model="strokeColor" @on-change="onColorChange" />
+          <ColorPicker v-model="strokeColor" @on-change="onColorChange" placement="left" />
         </div>
       </div>
     </template>
@@ -64,6 +64,7 @@ import useSelect from '@/hooks/select';
 import { Slider } from 'view-ui-plus';
 import { fabric } from 'fabric';
 import { Utils } from '@kuaitu/core';
+import { values } from 'lodash-es';
 
 interface IExtendImage {
   [x: string]: any;
@@ -118,6 +119,7 @@ const onSliderChange = (val: number) => {
 };
 
 const onColorChange = (val: string) => {
+  console.log('onColorChnage', val);
   strokeColor.value = val;
   updateStroke();
 };


### PR DESCRIPTION

close #444 

修复后
![image](https://github.com/nihaojob/vue-fabric-editor/assets/17617116/a06a6e16-2c12-4f6a-b670-0e5aaa1e8d4f)





