### PR TITLE
fix(plugin): resize插件拖拽适配画布居中

### DIFF
--- a/packages/core/plugin/ResizePlugin.ts
+++ b/packages/core/plugin/ResizePlugin.ts
@@ -161,7 +161,7 @@ class ResizePlugin implements IPluginTempl {
         case 'left':
           tempLength = Math.round(this.wsOffset.width - deltaViewX * 2);
           if (tempLength >= this.minSize.width) {
-            // this.dragEl.style.left = `${this.barOffset.x + deltaX}px`;
+            this.dragEl.style.left = `${this.barOffset.x + deltaX}px`;
             workspace.set('left', this.wsOffset.left + deltaViewX * 2);
             workspace.set('width', tempLength);
           } else {
@@ -172,7 +172,7 @@ class ResizePlugin implements IPluginTempl {
         case 'right':
           tempLength = Math.round(this.wsOffset.width + deltaViewX * 2);
           if (tempLength >= this.minSize.width) {
-            // this.dragEl.style.left = `${this.barOffset.x + deltaX}px`;
+            this.dragEl.style.left = `${this.barOffset.x + deltaX}px`;
             workspace.set('width', tempLength);
           } else {
             workspace.set('width', this.minSize.width);
@@ -181,7 +181,7 @@ class ResizePlugin implements IPluginTempl {
         case 'top':
           tempLength = Math.round(this.wsOffset.height - deltaViewY * 2);
           if (tempLength >= this.minSize.height) {
-            // this.dragEl.style.top = `${this.barOffset.y + deltaY}px`;
+            this.dragEl.style.top = `${this.barOffset.y + deltaY}px`;
             workspace.set('top', this.wsOffset.top + deltaViewY * 2);
             workspace.set('height', tempLength);
           } else {
@@ -192,7 +192,7 @@ class ResizePlugin implements IPluginTempl {
         case 'bottom':
           tempLength = Math.round(this.wsOffset.height + deltaViewY * 2);
           if (tempLength >= this.minSize.height) {
-            // this.dragEl.style.top = `${this.barOffset.y + deltaY}px`;
+            this.dragEl.style.top = `${this.barOffset.y + deltaY}px`;
             workspace.set('height', tempLength);
           } else {
             workspace.set('height', this.minSize.height);

--- a/packages/core/plugin/ResizePlugin.ts
+++ b/packages/core/plugin/ResizePlugin.ts
@@ -140,6 +140,7 @@ class ResizePlugin implements IPluginTempl {
         this.isDragging = false;
         this.dragEl.classList.remove('active');
         this.dragEl = null;
+        this.canvas.defaultCursor = 'default';
       }
     });
   }
@@ -152,16 +153,16 @@ class ResizePlugin implements IPluginTempl {
       const [scaleX, , , scaleY] = viewportTransform || [];
       const deltaX = e.clientX - this.startPoints.x;
       const deltaY = e.clientY - this.startPoints.y;
-      const deltaViewX = (e.clientX - this.startPoints.x) / scaleX;
-      const deltaViewY = (e.clientY - this.startPoints.y) / scaleY;
+      const deltaViewX = deltaX / scaleX;
+      const deltaViewY = deltaY / scaleY;
       const type = this.dragEl.id.split('-')[1];
       let tempLength = 0;
       switch (type) {
         case 'left':
-          tempLength = Math.round(this.wsOffset.width - deltaViewX);
+          tempLength = Math.round(this.wsOffset.width - deltaViewX * 2);
           if (tempLength >= this.minSize.width) {
-            this.dragEl.style.left = `${this.barOffset.x + deltaX}px`;
-            workspace.set('left', this.wsOffset.left + deltaViewX);
+            // this.dragEl.style.left = `${this.barOffset.x + deltaX}px`;
+            workspace.set('left', this.wsOffset.left + deltaViewX * 2);
             workspace.set('width', tempLength);
           } else {
             workspace.set('left', this.wsOffset.left + this.wsOffset.width - this.minSize.width);
@@ -169,19 +170,19 @@ class ResizePlugin implements IPluginTempl {
           }
           break;
         case 'right':
-          tempLength = Math.round(this.wsOffset.width + deltaViewX);
+          tempLength = Math.round(this.wsOffset.width + deltaViewX * 2);
           if (tempLength >= this.minSize.width) {
-            this.dragEl.style.left = `${this.barOffset.x + deltaX}px`;
+            // this.dragEl.style.left = `${this.barOffset.x + deltaX}px`;
             workspace.set('width', tempLength);
           } else {
             workspace.set('width', this.minSize.width);
           }
           break;
         case 'top':
-          tempLength = Math.round(this.wsOffset.height - deltaViewY);
+          tempLength = Math.round(this.wsOffset.height - deltaViewY * 2);
           if (tempLength >= this.minSize.height) {
-            this.dragEl.style.top = `${this.barOffset.y + deltaY}px`;
-            workspace.set('top', this.wsOffset.top + deltaViewY);
+            // this.dragEl.style.top = `${this.barOffset.y + deltaY}px`;
+            workspace.set('top', this.wsOffset.top + deltaViewY * 2);
             workspace.set('height', tempLength);
           } else {
             workspace.set('top', this.wsOffset.top + this.wsOffset.height - this.minSize.height);
@@ -189,9 +190,9 @@ class ResizePlugin implements IPluginTempl {
           }
           break;
         case 'bottom':
-          tempLength = Math.round(this.wsOffset.height + deltaViewY);
+          tempLength = Math.round(this.wsOffset.height + deltaViewY * 2);
           if (tempLength >= this.minSize.height) {
-            this.dragEl.style.top = `${this.barOffset.y + deltaY}px`;
+            // this.dragEl.style.top = `${this.barOffset.y + deltaY}px`;
             workspace.set('height', tempLength);
           } else {
             workspace.set('height', this.minSize.height);
@@ -206,6 +207,11 @@ class ResizePlugin implements IPluginTempl {
         this.canvas.clipPath = cloned;
         this.canvas.requestRenderAll();
       });
+      if (['left', 'right'].includes(type)) {
+        this.canvas.defaultCursor = 'ew-resize';
+      } else {
+        this.canvas.defaultCursor = 'ns-resize';
+      }
       this.editor.emit('sizeChange', workspace.width, workspace.height);
     }
   }


### PR DESCRIPTION
解决拖拽画布居中后，出现的以下问题：
1.拖拽时鼠标光标闪烁的问题
2.拖拽时控制条闪烁的问题
3.拖拽时控制条位置没有与鼠标同步



